### PR TITLE
Make compilable against fresh ffmpeg (3.2.4).

### DIFF
--- a/ffmpeg-php.c
+++ b/ffmpeg-php.c
@@ -104,9 +104,6 @@ PHP_INI_END()
  */
 PHP_MINIT_FUNCTION(ffmpeg)
 {
-    /* must be called before using avcodec libraries. */ 
-    avcodec_init();
-
     /* register all codecs */
     av_register_all();
     

--- a/ffmpeg_errorhandler.c
+++ b/ffmpeg_errorhandler.c
@@ -33,8 +33,9 @@
 
  */
 
-#include "php.h"
+#include <php.h>
 #include <avcodec.h>
+#include "ffmpeg_errorhandler.h"
 
 /* {{{ ffmpeg_errorhandler()
  */

--- a/ffmpeg_frame.c
+++ b/ffmpeg_frame.c
@@ -318,7 +318,6 @@ FFMPEG_PHP_METHOD(ffmpeg_frame, toGDImage)
 
 	FFMPEG_PHP_FETCH_IMAGE_RESOURCE(gd_img, return_value);
 
-	gdImageSetClip(gd_img, 0, 0, gd_img->sx, gd_img->sy);
 	if (_php_avframe_to_gd_image(ff_frame->av_frame, gd_img,
 	            ff_frame->width, ff_frame->height)) {
 	    zend_error(E_ERROR, "failed to convert frame to gd image");

--- a/ffmpeg_tools.c
+++ b/ffmpeg_tools.c
@@ -61,7 +61,7 @@ int img_convert(AVPicture *dst, int dst_pix_fmt,
         return 2;
     }
 
-    sws_scale(sws_ctx, src->data, src->linesize, 0, src_height, dst->data, dst->linesize);
+    sws_scale(sws_ctx, (const uint8_t * const *)src->data, src->linesize, 0, src_height, dst->data, dst->linesize);
     sws_freeContext(sws_ctx);
 
     return 0;
@@ -83,7 +83,7 @@ void img_resample(ImgReSampleContext * context, AVPicture * pxOut, const AVPictu
         shiftedInput.linesize[0] = pxIn->linesize[0];
         shiftedInput.linesize[1] = pxIn->linesize[1];
         shiftedInput.linesize[2] = pxIn->linesize[2];
-        sws_scale(context->context, (uint8_t**)shiftedInput.data, 
+        sws_scale(context->context, (const uint8_t * const *)shiftedInput.data, 
                 (int*)shiftedInput.linesize, 0, context->height - context->bandBottom - 
                 context->bandTop, pxOut->data, pxOut->linesize);
     }
@@ -99,8 +99,8 @@ ImgReSampleContext * img_resample_full_init (int owidth, int oheight, int iwidth
 	srcSurface = (iwidth - rightBand - leftBand)* (iheight - topBand - bottomBand);
     // We use bilinear when the source surface is big, and bicubic when the number of pixels to handle is less than 1 MPixels
     s->context = sws_getContext(iwidth - rightBand - leftBand, 
-            iheight - topBand - bottomBand, PIX_FMT_YUV420P, owidth, oheight, 
-            PIX_FMT_YUV420P, srcSurface > 1024000 ? SWS_FAST_BILINEAR : SWS_BICUBIC, 
+            iheight - topBand - bottomBand, AV_PIX_FMT_YUV420P, owidth, oheight, 
+            AV_PIX_FMT_YUV420P, srcSurface > 1024000 ? SWS_FAST_BILINEAR : SWS_BICUBIC, 
             NULL, NULL, NULL);
     if (s->context == NULL) {
         av_free(s);


### PR DESCRIPTION
Though some things complain about being deprecated, the code compiles and works. Based on work of @sunpoet, who maintains the [FreeBSD port](http://freshports.org/graphics/php5-ffmpeg).

Tested with tests bundled with @sunpoet's own [distribution](http://distcache.freebsd.org/local-distfiles/sunpoet/ffmpeg-php-0.6.0.20120114.tar.xz).